### PR TITLE
Memory Pool

### DIFF
--- a/example/deeplandmark/landmark.cpp
+++ b/example/deeplandmark/landmark.cpp
@@ -62,6 +62,7 @@ CNN::CNN(const string &network, const string &model) {
 
 vector<Point2f> CNN::forward(const Mat &data, const string &layer) {
   shared_ptr<Blob> blob = cnn->blob_by_name("data");
+  blob->Reshape(1, 1, data.rows, data.cols);
   float *blob_data = blob->mutable_cpu_data();
   const float *ptr = NULL;
   for (int i = 0; i < data.rows; i++) {

--- a/example/r-fcn/main.cpp
+++ b/example/r-fcn/main.cpp
@@ -45,6 +45,7 @@ int main(int argc, char* argv[]) {
   }
   Net net("../models/r-fcn/test_agnostic.prototxt");
   net.CopyTrainedLayersFrom("../models/r-fcn/resnet50_rfcn_final.caffemodel");
+  net.MarkOutputs({ "rois" });
 
   Mat img = imread("../r-fcn/004545.jpg");
   int height = img.rows;

--- a/example/r-fcn/main.cpp
+++ b/example/r-fcn/main.cpp
@@ -136,6 +136,12 @@ int main(int argc, char* argv[]) {
       cv::putText(img, buff, cv::Point(bbox.x1, bbox.y1), FONT_HERSHEY_PLAIN, 1, Scalar(0, 255, 0));
     }
   }
+  MemPoolState st = caffe::MemPoolGetState();
+  auto __Calc__ = [](int size) -> double {
+    return std::round(static_cast<double>(size) / (1024 * 1024) * 100) / 100;
+  };
+  LOG(INFO) << "[CPU] Hold " << __Calc__(st.cpu_mem) << " M, Not Uses " << __Calc__(st.unused_cpu_mem) << " M";
+  LOG(INFO) << "[GPU] Hold " << __Calc__(st.gpu_mem) << " M, Not Uses " << __Calc__(st.unused_gpu_mem) << " M";
   cv::imshow("result", img);
   cv::waitKey(0);
   return 0;

--- a/example/wgan/main.cpp
+++ b/example/wgan/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
   std::mt19937 gen(rd());
   std::normal_distribution<float> nd(0, 1);
   auto input = net.blob_by_name("data");
-  input->Reshape({1, 100, 1, 1});
+  input->Reshape({64, 100, 1, 1});
   float *data = input->mutable_cpu_data();
   const int n = input->count();
   for (int i = 0; i < n; ++i) {

--- a/example/wgan/main.cpp
+++ b/example/wgan/main.cpp
@@ -11,7 +11,7 @@
 /*! \brief Timer */
 class Timer {
   using Clock = std::chrono::high_resolution_clock;
-public:
+ public:
   /*! \brief start or restart timer */
   inline void Tic() {
     start_ = Clock::now();
@@ -26,7 +26,7 @@ public:
     return duration.count();
   }
 
-private:
+ private:
   Clock::time_point start_, end_;
 };
 
@@ -45,6 +45,7 @@ int main(int argc, char **argv) {
   std::mt19937 gen(rd());
   std::normal_distribution<float> nd(0, 1);
   auto input = net.blob_by_name("data");
+  input->Reshape({1, 100, 1, 1});
   float *data = input->mutable_cpu_data();
   const int n = input->count();
   for (int i = 0; i < n; ++i) {

--- a/include/caffe/base.hpp
+++ b/include/caffe/base.hpp
@@ -73,7 +73,7 @@ struct MemPoolState {
 };
 /*! \brief get memory usage in current thread */
 CAFFE_API MemPoolState MemPoolGetState();
-/*! \brief clear memory pool in current thread, be sure of what you want to do */
+/*! \brief clear unused memory pool in current thread */
 CAFFE_API void MemPoolClear();
 
 }  // namespace caffe

--- a/include/caffe/base.hpp
+++ b/include/caffe/base.hpp
@@ -38,14 +38,6 @@ private:                                              \
 #define NOT_IMPLEMENTED LOG(FATAL) << "Not Implemented Yet"
 #define NO_GPU LOG(FATAL) << "Cannot use GPU in CPU-only Caffe: check mode."
 
-#define STUB_GPU(classname)                                        \
-void classname::Forward_gpu(const vector<Blob*>& bottom,           \
-                            const vector<Blob*>& top) { NO_GPU; }
-
-#define STUB_GPU_FORWARD(classname, funcname)                          \
-void classname::funcname##_##gpu(const vector<Blob*>& bottom,          \
-                                 const vector<Blob*>& top) { NO_GPU; }
-
 namespace caffe {
 
 // Common functions and classes from std that caffe often uses.
@@ -70,6 +62,19 @@ CAFFE_API bool GPUAvailable();
  * \param device GPU device id, -1 for CPU
  */
 CAFFE_API void SetMode(DeviceMode mode, int device);
+
+//// ThreadLocal Memory Pool API
+
+struct MemPoolState {
+  int gpu_mem;  // gpu memory, calculate on all device memory used by this thread
+  int cpu_mem;  // cpu memory
+  int unused_gpu_mem;  // not used gpu memory
+  int unused_cpu_mem;  // not used cpu memory
+};
+/*! \brief get memory usage in current thread */
+CAFFE_API MemPoolState MemPoolGetState();
+/*! \brief clear memory pool in current thread, be sure of what you want to do */
+CAFFE_API void MemPoolClear();
 
 }  // namespace caffe
 

--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -188,9 +188,8 @@ class CAFFE_API Blob {
     return cpu_data()[offset(index)];
   }
 
-  const real_t* cpu_data() const;
-  void set_cpu_data(real_t* data);
   const int* gpu_shape() const;
+  const real_t* cpu_data() const;
   const real_t* gpu_data() const;
   real_t* mutable_cpu_data();
   real_t* mutable_gpu_data();
@@ -207,6 +206,9 @@ class CAFFE_API Blob {
    * shared_ptr calls its destructor when reset with the "=" operator.
    */
   void ShareData(const Blob& other);
+
+  /*! \brief release memory */
+  void Release();
 
   bool ShapeEquals(const BlobProto& other);
 
@@ -246,7 +248,6 @@ class BlobInt : public Blob {
   }
 
   const int* cpu_data() const;
-  void set_cpu_data(int* data);
   const int* gpu_data() const;
   int* mutable_cpu_data();
   int* mutable_gpu_data();

--- a/include/caffe/c_api.h
+++ b/include/caffe/c_api.h
@@ -154,6 +154,10 @@ CAFFE_API int CaffeSetMode(int mode, int device);
  * \note  this function is thread safe
  */
 CAFFE_API const char *CaffeGetLastError();
+/*!
+ * \brief clear unused memory in threaded memory pool
+ */
+CAFFE_API int CaffeMemoryPoolClear();
 
 #ifdef __cplusplus
 }

--- a/include/caffe/c_api.h
+++ b/include/caffe/c_api.h
@@ -67,6 +67,12 @@ CAFFE_API int CaffeNetCreateFromBuffer(const char *net_buffer, int nb_len,
 /*! \brief destroy network */
 CAFFE_API int CaffeNetDestroy(NetHandle net);
 /*!
+ * \brief mark internal blob as output
+ * \param net net handle
+ * \param name blob name
+ */
+CAFFE_API int CaffeNetMarkOutput(NetHandle net, const char *name);
+/*!
  * \brief forward network
  * \note  fill network input blobs before calling this function
  */

--- a/include/caffe/logging.hpp
+++ b/include/caffe/logging.hpp
@@ -220,6 +220,17 @@ class LogMessageFatal {
   void operator=(const LogMessageFatal&);
 };
 
+// This class is used to explicitly ignore values in the conditional
+// logging macros.  This avoids compiler warnings like "value computed
+// is not used" and "statement has no effect".
+class LogMessageVoidify {
+ public:
+  LogMessageVoidify() {}
+  // This has to be an operator with a precedence lower than << but
+  // higher than "?:". See its usage.
+  void operator&(std::ostream&) {}
+};
+
 }  // namespace caffe
 
 #endif  // CAFFE_LOGGING_H_

--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -129,6 +129,9 @@ class CAFFE_API Net {
   /// @brief calculate memory usage in MB
   real_t MemSize() const;
 
+  /// @brief mark extra output named blob
+  void MarkOutputs(const std::vector<std::string>& outs);
+
  protected:
   // Helpers for Init.
   /// @brief Append a new top blob to the net.
@@ -152,6 +155,7 @@ class CAFFE_API Net {
   /// @brief the blobs storing intermediate results between the layer.
   vector<shared_ptr<Blob> > blobs_;
   vector<string> blob_names_;
+  vector<int> blob_life_time_;
   std::map<string, int> blob_names_index_;
   /// @brief parameters in the network.
   vector<shared_ptr<Blob> > params_;

--- a/java/src/main/java/com/luoyetx/minicaffe/Net.java
+++ b/java/src/main/java/com/luoyetx/minicaffe/Net.java
@@ -37,6 +37,17 @@ public final class Net {
         }
     }
     /**
+     * mark network internal blob as output
+     * mark inside blob if you need to use it and it is not an output blob,
+     * otherwise you may get the wrong result
+     * @param name blob name
+     */
+    public void markOutput(String name) {
+        if (jniMarkOutput(name) != 0) {
+            throw new RuntimeException(Utils.GetLastError());
+        }
+    }
+    /**
      * forward the network
      * this function may make blobs in Java side out of date,
      * call `Blob.syncToJava` if need
@@ -61,6 +72,7 @@ public final class Net {
     private native int jniCreate(String net_path, String model_path);
     private native int jniCreateFromBuffer(byte[] net_buffer, byte[] model_buffer);
     private native int jniDestroy();
+    private native int jniMarkOutput(String name);
     private native int jniForward();
     private native int jniGetBlob(String name, Blob blob);
     // internal Net handle

--- a/java/src/test/java/MiniCaffeTest.java
+++ b/java/src/test/java/MiniCaffeTest.java
@@ -20,6 +20,7 @@ public class MiniCaffeTest {
         System.out.println("Create NIN");
         Net net = new Net("../build/model/nin.prototxt",
                           "../build/model/nin.caffemodel");
+        net.markOutput("conv1");
         Utils.OpenScope("nin");
         testForward(net);
         Utils.CloseScope();

--- a/python/minicaffe/net.py
+++ b/python/minicaffe/net.py
@@ -96,6 +96,17 @@ class Net(object):
             params[layer_name].append((name, param))
         return params
 
+    def mark_output(self, name):
+        """mark network internal blob as output, you need to mark it if you need the data,
+        and the blob is not an output blob, otherwise you may get the wrong result
+
+        Parameters
+        ----------
+        name: string
+            blob name to mark as an output
+        """
+        check_call(LIB.CaffeNetMarkOutput(self.handle, c_str(name)))
+
     def forward(self):
         """forward network, need to fill data blobs before call this function
         """

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -43,6 +43,7 @@ def test_network():
     # set up network
     net = mcaffe.Net(os.path.join(model_dir, 'resnet.prototxt'),
                      os.path.join(model_dir, 'resnet.caffemodel'))
+    net.mark_output("conv1")
     mcaffe.Profiler.open_scope("resnet")
     blob = net.get_blob('data')
     shape = blob.shape

--- a/src/blob.cpp
+++ b/src/blob.cpp
@@ -25,7 +25,8 @@ void Blob::Reshape(const vector<int>& shape) {
   count_ = 1;
   shape_.resize(shape.size());
   if (!shape_data_ || shape_data_->size() < shape.size() * sizeof(int)) {
-    shape_data_.reset(new SyncedMemory(shape.size() * sizeof(int)));
+    static_assert(kMaxBlobAxes*sizeof(int) == MemoryPool::kElementSize, "Static Assert Error");
+    shape_data_.reset(new SyncedMemory(kMaxBlobAxes * sizeof(int)));
   }
   int* shape_data = static_cast<int*>(shape_data_->mutable_cpu_data());
   for (int i = 0; i < shape.size(); ++i) {
@@ -96,7 +97,8 @@ real_t* Blob::mutable_gpu_data() {
 
 void Blob::Release() {
   data_ = nullptr;
-  shape_data_ = nullptr;
+  // no need to free shape data, cache it in blob level
+  //shape_data_ = nullptr;
   shape_.clear();
   count_ = 0;
   capacity_ = 0;

--- a/src/blob.cpp
+++ b/src/blob.cpp
@@ -37,7 +37,7 @@ void Blob::Reshape(const vector<int>& shape) {
     shape_[i] = shape[i];
     shape_data[i] = shape[i];
   }
-  if (count_ > capacity_) {
+  if (count_ != capacity_) {
     capacity_ = count_;
     data_.reset(new SyncedMemory(capacity_ * sizeof(real_t)));
   }
@@ -79,11 +79,6 @@ const real_t* Blob::cpu_data() const {
   return static_cast<const real_t*>(data_->cpu_data());
 }
 
-void Blob::set_cpu_data(real_t* data) {
-  CHECK(data);
-  data_->set_cpu_data(data);
-}
-
 real_t* Blob::mutable_cpu_data() {
   CHECK(data_);
   return static_cast<real_t*>(data_->mutable_cpu_data());
@@ -97,6 +92,14 @@ const real_t* Blob::gpu_data() const {
 real_t* Blob::mutable_gpu_data() {
   CHECK(data_);
   return static_cast<real_t*>(data_->mutable_gpu_data());
+}
+
+void Blob::Release() {
+  data_ = nullptr;
+  shape_data_ = nullptr;
+  shape_.clear();
+  count_ = 0;
+  capacity_ = 0;
 }
 
 void Blob::ShareData(const Blob& other) {
@@ -192,11 +195,6 @@ void Blob::ToProto(BlobProto* proto) const {
 const int* BlobInt::cpu_data() const {
   CHECK(data_);
   return static_cast<const int*>(data_->cpu_data());
-}
-
-void BlobInt::set_cpu_data(int* data) {
-  CHECK(data);
-  data_->set_cpu_data(data);
 }
 
 int* BlobInt::mutable_cpu_data() {

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -70,6 +70,12 @@ int CaffeNetDestroy(NetHandle net) {
   API_END();
 }
 
+int CaffeNetMarkOutput(NetHandle net, const char *name) {
+  API_BEGIN();
+  static_cast<caffe::Net*>(net)->MarkOutputs({name});
+  API_END();
+}
+
 int CaffeNetForward(NetHandle net) {
   API_BEGIN();
   static_cast<caffe::Net*>(net)->Forward();

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -206,3 +206,9 @@ int CaffeAPIHandleException(caffe::Error &e) {
   CaffeAPISetLastError(e.what());
   return -1;
 }
+
+int CaffeMemoryPoolClear() {
+  API_BEGIN();
+  caffe::MemPoolClear();
+  API_END();
+}

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -60,6 +60,14 @@ inline int CAFFE_GET_BLOCKS(const int N) {
 
 #endif  // USE_CUDA
 
+#define STUB_GPU(classname)                                        \
+void classname::Forward_gpu(const vector<Blob*>& bottom,           \
+                            const vector<Blob*>& top) { NO_GPU; }
+
+#define STUB_GPU_FORWARD(classname, funcname)                          \
+void classname::funcname##_##gpu(const vector<Blob*>& bottom,          \
+                                 const vector<Blob*>& top) { NO_GPU; }
+
 namespace caffe {
 
 // A singleton class to hold common caffe stuff, such as the handler that

--- a/src/jni/jni.c
+++ b/src/jni/jni.c
@@ -120,6 +120,17 @@ CaffeJNIMethod(Net, Destroy, jint)(JNIEnv *env, jobject thiz) {
   return 0;
 }
 
+CaffeJNIMethod(Net, MarkOutput, jint)(JNIEnv *env, jobject thiz,
+                                      jstring name) {
+  NetHandle net;
+  JNIGetHandleFromObj(thiz, net);
+  const char *name_cstr = (*env)->GetStringUTFChars(env, name, NULL);
+  CHECK_SUCCESS(CaffeNetMarkOutput(net, name_cstr), {
+    (*env)->ReleaseStringUTFChars(env, name, name_cstr);
+  });
+  return 0;
+}
+
 CaffeJNIMethod(Net, Forward, jint)(JNIEnv *env, jobject thiz) {
   NetHandle net;
   JNIGetHandleFromObj(thiz, net);

--- a/src/layer.hpp
+++ b/src/layer.hpp
@@ -115,6 +115,9 @@ class Layer {
   inline void Forward(const vector<Blob*>& bottom,
                       const vector<Blob*>& top);
 
+  /*! \brief clear internal buffer */
+  virtual void ClearInternalBuffer() {}
+
   /**
    * @brief Returns the vector of learnable parameter blobs.
    */
@@ -276,6 +279,7 @@ inline void Layer::Forward(const vector<Blob*>& bottom,
   default:
     LOG(FATAL) << "Unknown caffe mode.";
   }
+  ClearInternalBuffer();
 }
 
 // Serialize LayerParameter to protocol buffer

--- a/src/layers/base_conv_layer.hpp
+++ b/src/layers/base_conv_layer.hpp
@@ -20,6 +20,9 @@ class BaseConvolutionLayer : public Layer {
                           const vector<Blob*>& top);
   virtual void Reshape(const vector<Blob*>& bottom,
                        const vector<Blob*>& top);
+  virtual void ClearInternalBuffer() {
+    col_buffer_.Release();
+  }
 
   virtual int MinBottomBlobs() const { return 1; }
   virtual int MinTopBlobs() const { return 1; }

--- a/src/layers/batch_norm_layer.hpp
+++ b/src/layers/batch_norm_layer.hpp
@@ -45,6 +45,11 @@ class BatchNormLayer : public Layer {
                           const vector<Blob*>& top);
   virtual void Reshape(const vector<Blob*>& bottom,
                        const vector<Blob*>& top);
+  virtual void ClearInternalBuffer() {
+    mean_.Release();
+    variance_.Release();
+    temp_.Release();
+  }
 
   virtual const char* type() const { return "BatchNorm"; }
   virtual int ExactNumBottomBlobs() const { return 1; }

--- a/src/layers/bn_layer.hpp
+++ b/src/layers/bn_layer.hpp
@@ -17,6 +17,10 @@ class BNLayer : public Layer {
 		                      const vector<Blob*>& top);
 	virtual void Reshape(const vector<Blob*>& bottom,
 		                   const vector<Blob*>& top);
+  virtual void ClearInternalBuffer() {
+    broadcast_buffer_.Release();
+    x_norm_.Release();
+  }
 
 	virtual const char* type() const { return "BN"; }
 	virtual int ExactNumBottomBlobs() const { return 1; }

--- a/src/layers/cudnn/cudnn_conv_layer.hpp
+++ b/src/layers/cudnn/cudnn_conv_layer.hpp
@@ -29,6 +29,9 @@ class CuDNNConvolutionLayer : public ConvolutionLayer {
                           const vector<Blob*>& top);
   virtual void Reshape(const vector<Blob*>& bottom,
                        const vector<Blob*>& top);
+  virtual void ClearInternalBuffer() {
+    workspaceDataBlob.Release();
+  }
   virtual ~CuDNNConvolutionLayer();
 
  protected:
@@ -54,7 +57,8 @@ class CuDNNConvolutionLayer : public ConvolutionLayer {
   size_t *workspace_bwd_data_sizes_;
   size_t *workspace_bwd_filter_sizes_;
   size_t workspaceSizeInBytes;  // size of underlying storage
-  void *workspaceData;  // underlying storage
+  Blob workspaceDataBlob;  // hold the real data for workspace
+  void *workspaceData; // underlying storage
   void **workspace;  // aliases into workspaceData
 };
 #endif  // USE_CUDNN

--- a/src/layers/mvn_layer.hpp
+++ b/src/layers/mvn_layer.hpp
@@ -18,6 +18,11 @@ class MVNLayer : public Layer {
       : Layer(param) {}
   virtual void Reshape(const vector<Blob*>& bottom,
                        const vector<Blob*>& top);
+  virtual void ClearInternalBuffer() {
+    mean_.Release();
+    variance_.Release();
+    temp_.Release();
+  }
 
   virtual const char* type() const { return "MVN"; }
   virtual int ExactNumBottomBlobs() const { return 1; }

--- a/src/layers/proposal_layer.hpp
+++ b/src/layers/proposal_layer.hpp
@@ -17,6 +17,10 @@ class ProposalLayer : public Layer {
                        const vector<Blob*>& top) {
     //LOG(FATAL) << "Reshaping happens during the call to forward.";
   }
+  virtual void ClearInternalBuffer() {
+    proposals_.Release();
+    nms_mask_.Release();
+  }
 
   virtual const char* type() const { return "ProposalLayer"; }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -79,7 +79,7 @@ void Net::AppendTop(const NetParameter& param, const int layer_id,
     int blob_id = (*blob_name_to_idx)[blob_name];
     top_vecs_[layer_id].push_back(blobs_[blob_id].get());
     top_id_vecs_[layer_id].push_back(blob_id);
-    blob_life_time_[blob_id] = std::max(blob_life_time_[blob_id], layer_id);
+    blob_life_time_[blob_id] = std::max(blob_life_time_[blob_id], layer_id + 1);
   } else if (blob_name_to_idx &&
              blob_name_to_idx->find(blob_name) != blob_name_to_idx->end()) {
     // If we are not doing in-place computation but have duplicated blobs,
@@ -92,7 +92,7 @@ void Net::AppendTop(const NetParameter& param, const int layer_id,
     const int blob_id = blobs_.size();
     blobs_.push_back(blob_pointer);
     blob_names_.push_back(blob_name);
-    blob_life_time_.push_back(layer_id);
+    blob_life_time_.push_back(layer_id + 1);
     if (blob_name_to_idx) { (*blob_name_to_idx)[blob_name] = blob_id; }
     top_id_vecs_[layer_id].push_back(blob_id);
     top_vecs_[layer_id].push_back(blob_pointer.get());

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -56,6 +56,12 @@ void Net::Init(const NetParameter& param) {
       AppendParam(param, layer_id, param_id);
     }
   }
+  CHECK_EQ(std::string(layers_[0]->type()), std::string("Input"))
+      << "Network\'s first layer should be Input Layer.";
+  // for most case, not fully convolutional network, hold input data will be convenient
+  for (int blob_id : top_id_vecs_[0]) {
+    blob_life_time_[blob_id] = layers_.size();
+  }
   for (size_t blob_id = 0; blob_id < blob_names_.size(); ++blob_id) {
     blob_names_index_[blob_names_[blob_id]] = blob_id;
   }
@@ -223,7 +229,7 @@ void Net::MarkOutputs(const std::vector<std::string>& outs) {
       LOG(FATAL) << "blob (" << name << ") is not availiable in Net";
     }
     int blob_id = it->second;
-    blob_life_time_[blob_id] = std::numeric_limits<int>::max();
+    blob_life_time_[blob_id] = layers_.size();
   }
 }
 

--- a/src/syncedmem.cpp
+++ b/src/syncedmem.cpp
@@ -141,7 +141,7 @@ inline double MemSize(int size) {
 }
 
 inline bool ShouldBorrowMem(int has, int wants) {
-  static const int ratio = 2;
+  const int ratio = 2;
   return has / 2 <= wants;
 }
 

--- a/src/syncedmem.cpp
+++ b/src/syncedmem.cpp
@@ -4,20 +4,34 @@
 
 namespace caffe {
 
-SyncedMemory::~SyncedMemory() {
-  if (cpu_ptr_ && own_cpu_data_) {
-    CaffeFreeHost(cpu_ptr_, cpu_malloc_use_cuda_);
-  }
+using CpuBlock = MemoryPool::CpuBlock;
+using GpuBlock = MemoryPool::GpuBlock;
 
+static void CaffeMallocHost(CpuBlock& block, size_t size) {
+  block = MemoryPool::Get()->RequestCPU(size);
+}
+
+static void CaffeFreeHost(CpuBlock block) {
+  MemoryPool::Get()->ReturnCPU(block);
+}
+
+static void CaffeMallocDevice(GpuBlock& block, size_t size, int device) {
+  block = MemoryPool::Get()->RequestGPU(size, device);
+}
+
+static void CaffeFreeDevice(GpuBlock block) {
+  MemoryPool::Get()->ReturnGPU(block);
+}
+
+SyncedMemory::~SyncedMemory() {
+  if (cpu_block_.ptr) {
+    CaffeFreeHost(cpu_block_);
+    cpu_block_.ptr = nullptr;
+  }
 #ifdef USE_CUDA
-  if (gpu_ptr_ && own_gpu_data_) {
-    int initial_device;
-    cudaGetDevice(&initial_device);
-    if (gpu_device_ != -1) {
-      CUDA_CHECK(cudaSetDevice(gpu_device_));
-    }
-    CUDA_CHECK(cudaFree(gpu_ptr_));
-    cudaSetDevice(initial_device);
+  if (gpu_block_.ptr) {
+    CaffeFreeDevice(gpu_block_);
+    gpu_block_.ptr = nullptr;
   }
 #endif  // USE_CUDA
 }
@@ -25,18 +39,16 @@ SyncedMemory::~SyncedMemory() {
 inline void SyncedMemory::to_cpu() {
   switch (head_) {
   case UNINITIALIZED:
-    CaffeMallocHost(&cpu_ptr_, size_, &cpu_malloc_use_cuda_);
-    caffe_memset(size_, 0, cpu_ptr_);
+    CaffeMallocHost(cpu_block_, size_);
+    caffe_memset(size_, 0, cpu_block_.ptr);
     head_ = HEAD_AT_CPU;
-    own_cpu_data_ = true;
     break;
   case HEAD_AT_GPU:
 #ifdef USE_CUDA
-    if (cpu_ptr_ == NULL) {
-      CaffeMallocHost(&cpu_ptr_, size_, &cpu_malloc_use_cuda_);
-      own_cpu_data_ = true;
+    if (cpu_block_.ptr == nullptr) {
+      CaffeMallocHost(cpu_block_, size_);
     }
-    caffe_gpu_memcpy(size_, gpu_ptr_, cpu_ptr_);
+    caffe_gpu_memcpy(size_, gpu_block_.ptr, cpu_block_.ptr);
     head_ = SYNCED;
 #else
     NO_GPU;
@@ -50,21 +62,20 @@ inline void SyncedMemory::to_cpu() {
 
 inline void SyncedMemory::to_gpu() {
 #ifdef USE_CUDA
+  int device = -1;
   switch (head_) {
   case UNINITIALIZED:
-    CUDA_CHECK(cudaGetDevice(&gpu_device_));
-    CUDA_CHECK(cudaMalloc(&gpu_ptr_, size_));
-    caffe_gpu_memset(size_, 0, gpu_ptr_);
+    CUDA_CHECK(cudaGetDevice(&device));
+    CaffeMallocDevice(gpu_block_, size_, device);
+    caffe_gpu_memset(size_, 0, gpu_block_.ptr);
     head_ = HEAD_AT_GPU;
-    own_gpu_data_ = true;
     break;
   case HEAD_AT_CPU:
-    if (gpu_ptr_ == NULL) {
-      CUDA_CHECK(cudaGetDevice(&gpu_device_));
-      CUDA_CHECK(cudaMalloc(&gpu_ptr_, size_));
-      own_gpu_data_ = true;
+    if (gpu_block_.ptr == nullptr) {
+      CUDA_CHECK(cudaGetDevice(&device));
+      CaffeMallocDevice(gpu_block_, size_, device);
     }
-    caffe_gpu_memcpy(size_, cpu_ptr_, gpu_ptr_);
+    caffe_gpu_memcpy(size_, cpu_block_.ptr, gpu_block_.ptr);
     head_ = SYNCED;
     break;
   case HEAD_AT_GPU:
@@ -78,63 +89,131 @@ inline void SyncedMemory::to_gpu() {
 
 const void* SyncedMemory::cpu_data() {
   to_cpu();
-  return (const void*)cpu_ptr_;
-}
-
-void SyncedMemory::set_cpu_data(void* data) {
-  CHECK(data);
-  if (own_cpu_data_) {
-    CaffeFreeHost(cpu_ptr_, cpu_malloc_use_cuda_);
-  }
-  cpu_ptr_ = data;
-  head_ = HEAD_AT_CPU;
-  own_cpu_data_ = false;
+  return (const void*)cpu_block_.ptr;
 }
 
 const void* SyncedMemory::gpu_data() {
 #ifdef USE_CUDA
   to_gpu();
-  return (const void*)gpu_ptr_;
+  return (const void*)gpu_block_.ptr;
 #else
   NO_GPU;
-  return NULL;
-#endif  // USE_CUDA
-}
-
-void SyncedMemory::set_gpu_data(void* data) {
-#ifdef USE_CUDA
-  CHECK(data);
-  if (own_gpu_data_) {
-    int initial_device;
-    cudaGetDevice(&initial_device);
-    if (gpu_device_ != -1) {
-      CUDA_CHECK(cudaSetDevice(gpu_device_));
-    }
-    CUDA_CHECK(cudaFree(gpu_ptr_));
-    cudaSetDevice(initial_device);
-  }
-  gpu_ptr_ = data;
-  head_ = HEAD_AT_GPU;
-  own_gpu_data_ = false;
-#else
-  NO_GPU;
+  return nullptr;
 #endif  // USE_CUDA
 }
 
 void* SyncedMemory::mutable_cpu_data() {
   to_cpu();
   head_ = HEAD_AT_CPU;
-  return cpu_ptr_;
+  return cpu_block_.ptr;
 }
 
 void* SyncedMemory::mutable_gpu_data() {
 #ifdef USE_CUDA
   to_gpu();
   head_ = HEAD_AT_GPU;
-  return gpu_ptr_;
+  return gpu_block_.ptr;
 #else
   NO_GPU;
-  return NULL;
+  return nullptr;
+#endif  // USE_CUDA
+}
+
+//// MemoryPool
+
+MemoryPool* MemoryPool::Get() {
+  return ThreadLocalStore<MemoryPool>::Get();
+}
+
+MemoryPool::~MemoryPool() {
+  for (auto it = cpu_pool_.begin(); it != cpu_pool_.end(); it++) {
+    free(it->second.ptr);
+  }
+#ifdef USE_CUDA
+  for (auto it = gpu_pool_.begin(); it != gpu_pool_.end(); it++) {
+    cudaSetDevice(it->second.device);
+    cudaError_t err = cudaFree(it->second.ptr);
+    // ignore unloading error, as memory has already been recycled
+    if (err != cudaSuccess && err != cudaErrorCudartUnloading) {
+      LOG(FATAL) << "CUDA: " << cudaGetErrorString(err);
+    }
+  }
+#endif  // USE_CUDA
+}
+
+inline double MemSize(int size) {
+  return std::round(static_cast<double>(size) / (1024 * 1024));
+}
+
+inline bool ShouldBorrowMem(int has, int wants) {
+  static const int ratio = 2;
+  return has / 2 < wants;
+}
+
+CpuBlock MemoryPool::RequestCPU(int size) {
+  CpuKey key{size};
+  auto it = unused_cpu_pool_.lower_bound(key);
+  if (it == unused_cpu_pool_.end() || !ShouldBorrowMem(it->second.size,size)) {
+    CpuBlock block;
+    block.size = size;
+    block.ptr = malloc(size);
+    cpu_pool_.insert(CpuBlockPair{block.Key(), block});
+    DLOG(INFO) << "[CPU] Requested " << MemSize(size) << ", Create " << MemSize(block.size);
+    return block;
+  }
+  else {
+    CpuBlock block = it->second;
+    unused_cpu_pool_.erase(it);
+    DLOG(INFO) << "[CPU] Requested " << MemSize(size) << ", Get " << MemSize(block.size);
+    return block;
+  }
+}
+
+void MemoryPool::ReturnCPU(CpuBlock block) {
+  DLOG(INFO) << "[CPU] Return " << MemSize(block.size);
+  unused_cpu_pool_.insert(CpuBlockPair{block.Key(), block});
+}
+
+GpuBlock MemoryPool::RequestGPU(int size, int device) {
+#ifdef USE_CUDA
+  GpuKey key{device, size};
+  auto it = unused_gpu_pool_.lower_bound(key);
+  if (it == unused_gpu_pool_.end() || it->second.device != device ||
+      !ShouldBorrowMem(it->second.size, size)) {
+    int cur_device;
+    CUDA_CHECK(cudaGetDevice(&cur_device));
+    if (cur_device != device) {
+      CUDA_CHECK(cudaSetDevice(device));
+    }
+    GpuBlock block;
+    block.size = size;
+    block.device = device;
+    CUDA_CHECK(cudaMalloc(&block.ptr, size));
+    if (cur_device != device) {
+      CUDA_CHECK(cudaSetDevice(cur_device));
+    }
+    gpu_pool_.insert(GpuBlockPair{block.Key(), block});
+    DLOG(INFO) << "[GPU] Requested " << MemSize(size) << ", Create " << MemSize(block.size);
+    return block;
+  }
+  else {
+    GpuBlock block = it->second;
+    unused_gpu_pool_.erase(it);
+    DLOG(INFO) << "[GPU] Requested " << MemSize(size) << ", Get " << MemSize(block.size);
+    return block;
+  }
+#else
+  NO_GPU;
+  return GpuBlock();
+#endif  // USE_CUDA
+}
+
+void MemoryPool::ReturnGPU(GpuBlock block) {
+#ifdef USE_CUDA
+  DLOG(INFO) << "[GPU] Return " << MemSize(block.size);
+  unused_gpu_pool_.insert(GpuBlockPair{block.Key(), block});
+#else
+  NO_GPU;
 #endif  // USE_CUDA
 }
 

--- a/src/syncedmem.cpp
+++ b/src/syncedmem.cpp
@@ -249,6 +249,7 @@ void MemoryPool::Clear() {
   for (auto& block : cpu_pool_) {
     free(block.ptr);
   }
+  cpu_pool_.clear();
 #ifdef USE_CUDA
   for (auto& block : gpu_pool_) {
     cudaSetDevice(block.device);
@@ -258,6 +259,7 @@ void MemoryPool::Clear() {
       LOG(FATAL) << "CUDA: " << cudaGetErrorString(err);
     }
   }
+  gpu_pool_.clear();
 #endif  // USE_CUDA
 }
 

--- a/src/syncedmem.cpp
+++ b/src/syncedmem.cpp
@@ -135,7 +135,7 @@ inline double MemSize(int size) {
 
 inline bool ShouldBorrowMem(int has, int wants) {
   static const int ratio = 2;
-  return has / 2 < wants;
+  return has / 2 <= wants;
 }
 
 CpuBlock MemoryPool::RequestCPU(int size) {

--- a/src/syncedmem.cpp
+++ b/src/syncedmem.cpp
@@ -258,7 +258,7 @@ MemBlock MemoryPool::RequestGPU(int size, int device) {
       if (cur_device != device) {
         CUDA_CHECK(cudaSetDevice(cur_device));
       }
-      gpu_pool_.push(block);
+      gpu_pool_.push_back(block);
       DLOG(INFO) << "[GPU] Requested " << MemSize(size) << " M, Create " << MemSize(block.size) << " M";
       return block;
     }

--- a/src/syncedmem.hpp
+++ b/src/syncedmem.hpp
@@ -27,7 +27,7 @@ class MemoryPool {
   void ReturnGPU(MemBlock gpu_block);
 
   MemPoolState GetState();
-  void Clear();
+  void ClearUnused();
 
  private:
   friend ThreadLocalStore<MemoryPool>;

--- a/src/syncedmem.hpp
+++ b/src/syncedmem.hpp
@@ -36,6 +36,9 @@ class MemoryPool {
   void ReturnCPU(CpuBlock cpu_block);
   void ReturnGPU(GpuBlock gpu_block);
 
+  MemPoolState GetState();
+  void Clear();
+
  private:
   friend ThreadLocalStore<MemoryPool>;
   MemoryPool() {}

--- a/src/syncedmem.hpp
+++ b/src/syncedmem.hpp
@@ -27,7 +27,7 @@ class MemoryPool {
   void ReturnGPU(MemBlock gpu_block);
 
   MemPoolState GetState();
-  void ClearUnused();
+  void Clear();
 
  private:
   friend ThreadLocalStore<MemoryPool>;
@@ -35,10 +35,9 @@ class MemoryPool {
   ~MemoryPool();
   DISABLE_COPY_AND_ASSIGN(MemoryPool);
 
-  std::vector<MemBlock> cpu_pool_;
-  std::vector<MemBlock> gpu_pool_;
-  std::multimap<CpuKey, MemBlock> unused_cpu_pool_;
-  std::multimap<GpuKey, MemBlock> unused_gpu_pool_;
+  //// pool for unused memory
+  std::multimap<CpuKey, MemBlock> cpu_pool_;
+  std::multimap<GpuKey, MemBlock> gpu_pool_;
 
   //// small object pool on CPU for size <= 128 bytes
   const int kMaxGPUs = 8;
@@ -50,6 +49,10 @@ class MemoryPool {
   LinkedList* head_;
   MemBlock curr_page_;
   int curr_ptr_;
+  std::vector<MemBlock> obj_pool_;
+
+  //// memory pool status
+  MemPoolState st_;
 };
 
 class SyncedMemory {

--- a/src/syncedmem.hpp
+++ b/src/syncedmem.hpp
@@ -40,19 +40,16 @@ class MemoryPool {
   std::multimap<CpuKey, MemBlock> unused_cpu_pool_;
   std::multimap<GpuKey, MemBlock> unused_gpu_pool_;
 
-  //// small object pool for size <= 128 bytes
+  //// small object pool on CPU for size <= 128 bytes
   const int kMaxGPUs = 8;
   const int kElementSize = 128;
   const int kPageSize = 1 << 20;  // 1 MB
   struct LinkedList {
     LinkedList* next{nullptr};
   };
-  LinkedList* cpu_head_;
-  MemBlock cpu_curr_page_;
-  int cpu_curr_ptr_;
-  std::vector<LinkedList*> gpu_heads_;  // one head per GPU
-  std::vector<MemBlock> gpu_curr_pages_;
-  std::vector<int> gpu_curr_ptrs_;
+  LinkedList* head_;
+  MemBlock curr_page_;
+  int curr_ptr_;
 };
 
 class SyncedMemory {

--- a/src/syncedmem.hpp
+++ b/src/syncedmem.hpp
@@ -8,9 +8,18 @@
 
 namespace caffe {
 
-/*! \brief Thread local MemoryPool */
+/*!
+ * \brief Thread local MemoryPool
+ *  This memory pool holds all memory for blobs in every thread.
+ */
 class MemoryPool {
  public:
+  // small object size
+  enum {
+    kElementSize = 128,
+    kPageSize = 1 << 20,  // 1 MB
+  };
+
   using GpuKey = std::pair<int, int>;
   using CpuKey = int;
   struct MemBlock {
@@ -20,13 +29,26 @@ class MemoryPool {
   };
 
   static MemoryPool* Get();
-
+  /*!
+   * \brief request memory from cpu
+   * \param size memory size
+   * \return memory block holds data size >= size
+   */
   MemBlock RequestCPU(int size);
+  /*!
+   * \brief request memory from gpu
+   * \param size memory size
+   * \param device gpu device id
+   * \return memory block holds data size >= size
+   */
   MemBlock RequestGPU(int size, int device);
+  /*! \brief return cpu memory block */
   void ReturnCPU(MemBlock cpu_block);
+  /*! \brief return gpu memory block */
   void ReturnGPU(MemBlock gpu_block);
-
+  /*! \brief get memory pool statistics */
   MemPoolState GetState();
+  /*! \brief free all unused memory in pool */
   void Clear();
 
  private:
@@ -40,9 +62,6 @@ class MemoryPool {
   std::multimap<GpuKey, MemBlock> gpu_pool_;
 
   //// small object pool on CPU for size <= 128 bytes
-  const int kMaxGPUs = 8;
-  const int kElementSize = 128;
-  const int kPageSize = 1 << 20;  // 1 MB
   struct LinkedList {
     LinkedList* next{nullptr};
   };

--- a/src/syncedmem.hpp
+++ b/src/syncedmem.hpp
@@ -41,9 +41,9 @@ class MemoryPool {
   std::multimap<GpuKey, MemBlock> unused_gpu_pool_;
 
   //// small object pool for size <= 128 bytes
-  static const int kMaxGPUs = 8;
-  static const int kElementSize = 128;
-  static const int kPageSize = 1 << 20;  // 1 MB
+  const int kMaxGPUs = 8;
+  const int kElementSize = 128;
+  const int kPageSize = 1 << 20;  // 1 MB
   struct LinkedList {
     LinkedList* next{nullptr};
   };

--- a/tests/run_net.cpp
+++ b/tests/run_net.cpp
@@ -189,7 +189,6 @@ int main(int argc, char *argv[]) {
     timer.Toc();
     LOG(INFO) << "Forward NIN costs " << timer.Elasped() << " ms";
   }
-  caffe::MemPoolClear();
   // test googlenet, model from https://github.com/BVLC/caffe/wiki/Model-Zoo#cnn-models-for-salient-object-subitizing
   {
     LOG(INFO) << "Test GoogLeNet";
@@ -202,7 +201,6 @@ int main(int argc, char *argv[]) {
     timer.Toc();
     LOG(INFO) << "Forward GoogLeNet costs " << timer.Elasped() << " ms";
   }
-  caffe::MemPoolClear();
   // test resnet, model from https://github.com/BVLC/caffe/wiki/Model-Zoo#imagenet-pre-trained-models-with-batch-normalization
   {
     LOG(INFO) << "Test ResNet";
@@ -236,6 +234,13 @@ int main(int argc, char *argv[]) {
   shared_ptr<NetParameter> model_param = ReadBinaryNetParameterFromBuffer(caffemodel.c_str(), caffemodel.length());
   Net net(*network_param);
   net.CopyTrainedLayersFrom(*model_param);
+
+  MemPoolState st = caffe::MemPoolGetState();
+  auto __Calc__ = [](int size) -> double {
+    return std::round(static_cast<double>(size) / (1024 * 1024) * 100) / 100;
+  };
+  LOG(INFO) << "[CPU] Hold " << __Calc__(st.cpu_mem) << " M, Not Uses " << __Calc__(st.unused_cpu_mem) << " M";
+  LOG(INFO) << "[GPU] Hold " << __Calc__(st.gpu_mem) << " M, Not Uses " << __Calc__(st.unused_gpu_mem) << " M";
 
   // test multi-thread
   const int kThreads = 3;

--- a/tests/run_net.cpp
+++ b/tests/run_net.cpp
@@ -189,6 +189,7 @@ int main(int argc, char *argv[]) {
     timer.Toc();
     LOG(INFO) << "Forward NIN costs " << timer.Elasped() << " ms";
   }
+  caffe::MemPoolClear();
   // test googlenet, model from https://github.com/BVLC/caffe/wiki/Model-Zoo#cnn-models-for-salient-object-subitizing
   {
     LOG(INFO) << "Test GoogLeNet";
@@ -201,6 +202,7 @@ int main(int argc, char *argv[]) {
     timer.Toc();
     LOG(INFO) << "Forward GoogLeNet costs " << timer.Elasped() << " ms";
   }
+  caffe::MemPoolClear();
   // test resnet, model from https://github.com/BVLC/caffe/wiki/Model-Zoo#imagenet-pre-trained-models-with-batch-normalization
   {
     LOG(INFO) << "Test ResNet";
@@ -256,4 +258,5 @@ void thread_test() {
   auto test = ResNet("model/resnet.prototxt", "model/resnet.caffemodel");
   LOG(INFO) << "Memory Used: " << test.net->MemSize() << " MB";
   test.Forward();
+  caffe::MemPoolClear();
 }

--- a/tools/parse_mem.py
+++ b/tools/parse_mem.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python2.7
+# pylint: disable=invalid-name, no-member, line-too-long
+
+import os
+import re
+import argparse
+from collections import namedtuple
+import numpy as np
+from matplotlib import pyplot as plt
+
+
+Entry = namedtuple('Entry', ('type', 'device', 'time', 's1', 's2'))
+
+class MemStatistic(object):
+    """memory statistic
+
+    A Memory Entry (type, time, size1, size2)
+    For hit request: ('hit', time, has, wants)
+    For miss request: ('miss', time, creates, wants), creates == wants
+    For return: ('return', time, rets, rets)
+    """
+
+    def __init__(self):
+        self.entry_ = []
+        self.clock_ = 0
+
+    def request_hit(self, dev, has, wants):
+        """request hit the memory pool and not create any extra memory
+        """
+        self.entry_.append(Entry('hit', dev, self.clock_, has, wants))
+        self._clock_update()
+
+    def request_miss(self, dev, creates, wants):
+        """request miss the memory pool and create an extra memory
+        """
+        self.entry_.append(Entry('miss', dev, self.clock_, creates, wants))
+        self._clock_update()
+
+    def return_mem(self, dev, size):
+        """return a memory entry to the pool
+        """
+        self.entry_.append(Entry('return', dev, self.clock_, size, size))
+        self._clock_update()
+
+    def _clock_update(self):
+        """update internal clock
+        """
+        self.clock_ += 1
+
+    def plot(self):
+        """plot statistic
+        """
+        # total memory over time
+        n = len(self.entry_)
+        x_time = np.arange(n + 1)
+        y_total = np.zeros(n + 1)
+        y_unused = np.zeros(n + 1)
+        for i, entry in enumerate(self.entry_):
+            ts = i + 1
+            y_total[ts] = y_total[ts - 1]
+            y_unused[ts] = y_unused[ts - 1]
+            if entry.type == 'hit':
+                y_unused[ts] -= entry.s1
+            elif entry.type == 'miss':
+                y_total[ts] += entry.s1
+            else:
+                y_unused[ts] += entry.s1
+        # convert to M
+        y_total /= 1024 * 1024
+        y_unused /= 1024 * 1024
+        # plot over time
+        plt.xlabel('time / tick')
+        plt.ylabel('memory / MB')
+        plt.plot(x_time, y_total, 'r', label='all')
+        #plt.plot(x_time, y_unused, 'g', label='free')
+        plt.plot(x_time, y_total - y_unused, 'b', label='used')
+        plt.legend(loc='upper left')
+        plt.show()
+
+
+def parse_args():
+    """parse command argument
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input', type=str, help="memory statistic result file")
+    args = parser.parse_args()
+    assert os.path.exists(args.input), "input file not exists"
+    return args
+
+def convert(s, t):
+    """convert memory size of type
+    """
+    assert t in 'BKM'
+    if t == 'B':
+        return int(s)
+    elif t == 'K':
+        return int(s * 1024)
+    else:
+        return int(s * 1024 * 1024)
+
+if __name__ == '__main__':
+    args = parse_args()
+    statistic = MemStatistic()
+    with open(args.input, 'r') as fin:
+        for i, line in enumerate(fin):
+            if 'Requested' in line:
+                if 'Get' in line:
+                    # hit
+                    g = re.search(r'Requested (.+) ([B|K|M]), Get (.+) ([B|K|M])', line).groups()
+                    assert len(g) == 4
+                    wants = convert(float(g[0]), g[1])
+                    has = convert(float(g[2]), g[3])
+                    dev = 'cpu' if '[CPU]' in line else 'gpu'
+                    statistic.request_hit(dev, has, wants)
+                else:
+                    # miss
+                    assert 'Create' in line
+                    g = re.search(r'Requested (.+) ([B|K|M]), Create (.+) ([B|K|M])', line).groups()
+                    assert len(g) == 4
+                    wants = convert(float(g[0]), g[1])
+                    creates = convert(float(g[2]), g[3])
+                    assert wants == creates
+                    dev = 'cpu' if '[CPU]' in line else 'gpu'
+                    statistic.request_miss(dev, creates, wants)
+            elif 'Return' in line:
+                g = re.search(r'Return (.+) ([B|K|M])', line).groups()
+                assert len(g) == 2
+                rets = convert(float(g[0]), g[1])
+                dev = 'cpu' if '[CPU]' in line else 'gpu'
+                statistic.return_mem(dev, rets)
+    # plot
+    statistic.plot()


### PR DESCRIPTION
This PR implement strategy-1 mentioned in #29 . Memory usage of example r-fcn can be reduced from 2G to 500MB on CPU context and from 1.8G to 600M on GPU context (with CUDNN).

Some works still need to be done.

1. impl a small object pool to hold data shapes, which usually < 128 bytes.
2. test on fully convolution network, current pool strategy borrow memory to blob only if requested memory size >= half of real memory size. This may cause memory issue when using fully convolution network.