### PR TITLE
Solves build error where pthread can't be found

### DIFF
--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1,6 +1,6 @@
 # cpp
 add_executable(run_net ${CMAKE_CURRENT_LIST_DIR}/run_net.cpp)
-target_link_libraries(run_net caffe)
+target_link_libraries(run_net caffe -lpthread)
 
 # c
 add_executable(run_net_c ${CMAKE_CURRENT_LIST_DIR}/run_net.c)


### PR DESCRIPTION
Without this change on Ubuntu 16.04:

[100%] Linking CXX executable run_net
/usr/bin/ld: CMakeFiles/run_net.dir/tests/run_net.cpp.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [run_net] Error 1
make[1]: *** [CMakeFiles/run_net.dir/all] Error 2
CMakeFiles/run_net.dir/build.make:99: recipe for target 'run_net' failed
CMakeFiles/Makefile2:141: recipe for target 'CMakeFiles/run_net.dir/all' failed